### PR TITLE
fix: anchor content-type parsing to beginning of string

### DIFF
--- a/lua/http-client/core/struct/response.lua
+++ b/lua/http-client/core/struct/response.lua
@@ -42,7 +42,7 @@ function Response.new(resp_data)
                 self.headers_to_dict[key] = value
 
                 -- Identify and store the content type
-                if key:lower():match("content%-type") then
+                if key:lower():match("^content%-type") then
                     self.content_type = vim.fn.trim(value:lower())
                 end
             end


### PR DESCRIPTION
When parsing the content-type of a response, the match needs to be anchored to the beginning of the string. Otherwise the check will also match headers like x-content-type-options which will set an incorrect value and prevent correct rendering.